### PR TITLE
Restructure and add standin for compiler exe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
+name = "snowflake"
+version = "0.1.0"
+dependencies = [
+ "parser",
+ "tag",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,14 @@
+[package]
+name = "snowflake"
+version = "0.1.0"
+author = "the snowflake authors"
+
 [workspace]
 members = [
   "lib/parser",
   "lib/tag",
 ]
+
+[dependencies]
+parser = { path = "lib/parser" }
+tag = { path = "lib/tag" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,6 @@
+extern crate parser;
+extern crate tag;
+
+fn main() {
+    println!("Hello world!");
+}


### PR DESCRIPTION
This just creates an executable that will become the compiler and rewrites Cargo.toml to include the libs in the deps